### PR TITLE
Update 4.10.embeded.dns.haproxy.registry.podman.md

### DIFF
--- a/redhat/ocp4/4.10/4.10.embeded.dns.haproxy.registry.podman.md
+++ b/redhat/ocp4/4.10/4.10.embeded.dns.haproxy.registry.podman.md
@@ -89,11 +89,11 @@ mirror:
         versions:
           - '4.10.28'
           - '4.10.26'
-  additionalImages:
-    - name: registry.redhat.io/redhat/redhat-operator-index:v4.10
-    - name: registry.redhat.io/redhat/certified-operator-index:v4.10
-    - name: registry.redhat.io/redhat/community-operator-index:v4.10
-    - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.10
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.10
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.10
+    - catalog: registry.redhat.io/redhat/community-operator-index:v4.10
+    - catalog: registry.redhat.io/redhat/redhat-marketplace-index:v4.10
 
 EOF
 


### PR DESCRIPTION
The `additionalImages` will mirror the index image only, not mirror the bundle images contained in that index image. So, should use the `operators.catalog` instead.
```yaml
  additionalImages:
    - name: registry.redhat.io/redhat/redhat-operator-index:v4.10
    - name: registry.redhat.io/redhat/certified-operator-index:v4.10
    - name: registry.redhat.io/redhat/community-operator-index:v4.10
    - name: registry.redhat.io/redhat/redhat-marketplace-index:v4.10
```